### PR TITLE
replace subprocess.mswindows to support Python35

### DIFF
--- a/popenasync.py
+++ b/popenasync.py
@@ -23,7 +23,7 @@ if sys.version_info >= (3,):
 else:
     null_byte = '\x00'
 
-if subprocess.mswindows:
+if sys.platform == 'win32':
     if sys.version_info >= (3,):
         # Test date should be in ascii.
         def encode(s):
@@ -142,7 +142,7 @@ class Popen(subprocess.Popen):
         getattr(self, which).close()
         setattr(self, which, None)
     
-    if subprocess.mswindows:
+    if sys.platform == 'win32':
         def kill(self):
             # Recipes
             #http://me.in-berlin.de/doc/python/faq/windows.html#how-do-i-emulate-os-kill-in-windows


### PR DESCRIPTION
"Actually, subprocess.mswindows is an internal-only API so ideally it shouldn't be used at all. However, in Python 3.5 the attribute has been renamed to subprocess._mswindows"